### PR TITLE
Remove unecessary Dockerfile directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,3 @@ ADD requirements.txt /opt/website
 # Install application dependencies
 WORKDIR /opt/website
 RUN virtualenv . && pip install -r requirements.txt
-
-# Add all app code to /opt/website directory
-ADD . /opt/website


### PR DESCRIPTION
Removing the directive that adds the application code to the application root directory on the web container. This directive is unnecessary because the application root directory on the host is mounted at `/opt/website` on the container so that any changes to the application code on the host are immediately reflected in the running application on the container