### PR TITLE
Add phantomjs package to quizme_web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,40 @@ ADD requirements.txt /opt/website
 # Install application dependencies
 WORKDIR /opt/website
 RUN virtualenv . && pip install -r requirements.txt
+
+# Install phantomjs for selenium browser testing
+RUN apt-get update; \
+    apt-get install -y \
+    bison \
+    build-essential \
+    curl \
+    flex \
+    g++ \
+    git \
+    gperf \
+    sqlite3 \
+    libsqlite3-dev \
+    fontconfig \
+    libfontconfig1 \
+    libfontconfig1-dev \
+    libfreetype6 \
+    libfreetype6-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libssl-dev \
+    libqt5webkit5-dev \
+    ruby \
+    perl \
+    unzip \
+    wget
+
+RUN mkdir -p /usr/src; \
+    cd /usr/src; \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.0.0-source.zip; \
+    unzip phantomjs-2.0.0-source.zip; \
+    rm phantomjs-2.0.0-source.zip; \
+    cd phantomjs-2.0.0; \
+    ./build.sh --confirm
+
+RUN cp /usr/src/phantomjs-2.0.0/bin/phantomjs /usr/local/bin/phantomjs


### PR DESCRIPTION
The container including phantomjs finally built, and I was able to run the selenium tests with phantomjs! It took about 1 hour to build :( , which is way too long, I'd like to decrease that significantly if possible.
```
$ docker-compose run web make test_phantomjs
Starting quizme_db_1
# ROB_SELENIUM_BROWSER=phantomjs ./manage.py test --failfast
ROB_SELENIUM_BROWSER=phantomjs ./manage.py test
Creating test database for alias 'default'...
.......
----------------------------------------------------------------------
Ran 7 tests in 9.638s

OK
Destroying test database for alias 'default'...
```