### PR TITLE
implement new get_next_question algorithm; increase performance

### DIFF
--- a/questions/models.py
+++ b/questions/models.py
@@ -149,13 +149,18 @@ class Schedule(CreatedBy):
             self.interval_unit = 'seconds'
         interval = relativedelta(**({self.interval_unit: interval_num}))
         # TODO: set interval_secs
-        try:
-            self.date_show_next = time_now + interval
-        except TypeError as exception:
-            print("Exception: interval_unit=[%s] interval_num=[%s] type(interval_num)=[%s] "
-                  "exception=[%s]" % (
-                      self.interval_unit, interval_num, type(interval_num), exception))
-            raise
+        if self.date_show_next:
+            # It's already set, so don't modify it.  e.g., modifying the
+            # schedule in the django admin.
+            pass
+        else:
+            try:
+                self.date_show_next = time_now + interval
+            except TypeError as exception:
+                print("Exception: interval_unit=[%s] interval_num=[%s] type(interval_num)=[%s] "
+                      "exception=[%s]" % (
+                          self.interval_unit, interval_num, type(interval_num), exception))
+                raise
         return super(Schedule, self).save(*args, **kwargs)
 
 

--- a/questions/tests/test_get_next_question.py
+++ b/questions/tests/test_get_next_question.py
@@ -6,6 +6,9 @@ from questions import models, util
 from questions.views import _get_next_question
 from questions.views import NextQuestion
 
+NUM_QUERIES_SCHEDULED_BEFORE_NOW = 3  # scheduled question is due to be shown before now
+NUM_QUERIES_NO_QUESTIONS = 5  # number of queries expected when no questions are found
+
 
 class TestGetNextQuestion(TestCase):
 
@@ -29,7 +32,10 @@ class TestGetNextQuestion(TestCase):
             question='fakebar',
         )
 
-        with self.assertNumQueries(2):
+        # One untagged question that doesn't get returned because it has
+        # no tags.
+
+        with self.assertNumQueries(NUM_QUERIES_NO_QUESTIONS):
             next_question = _get_next_question(self.user)
 
         self.assertIsInstance(next_question, NextQuestion)
@@ -45,7 +51,7 @@ class TestGetNextQuestion(TestCase):
         util.assign_question_to_user(self.user, question, 'fake_tag')
         util.schedule_question_for_user(self.user, question)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(NUM_QUERIES_SCHEDULED_BEFORE_NOW):
             next_question = _get_next_question(self.user)
 
         self.assertIsInstance(next_question, NextQuestion)
@@ -62,7 +68,7 @@ class TestGetNextQuestion(TestCase):
             util.assign_question_to_user(self.user, question, 'fake_tag')
             util.schedule_question_for_user(self.user, question)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(NUM_QUERIES_SCHEDULED_BEFORE_NOW):
             next_question = _get_next_question(self.user)
 
         self.assertIsInstance(next_question, NextQuestion)

--- a/questions/tests/tests.py
+++ b/questions/tests/tests.py
@@ -4,14 +4,16 @@ when you run "manage.py test".
 
 Replace this with more appropriate tests for your application.
 """
+from datetime import datetime, timedelta
 import os
 
 from django.test import LiveServerTestCase, TestCase
 from selenium.common.exceptions import StaleElementReferenceException
+import pytz
 
 from emailusername.models import User
-from questions import forms, models
-from questions.tests.test_helpers import FuzzyInt
+from questions import forms
+from questions.models import Answer, Attempt, Question, QuestionTag, Schedule, Tag, UserTag
 from questions.views import _get_next_question
 
 # By default, LiveServerTestCase uses port 8081.
@@ -19,6 +21,7 @@ from questions.views import _get_next_question
 # os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = 'localhost:8000'
 
 WAIT_TIME = 5
+
 
 # phantomjs archives for Windows, OSX, and Linux can be found at: http://phantomjs.org/download.html
 class BrowserTests(LiveServerTestCase):
@@ -116,17 +119,17 @@ class BrowserTests(LiveServerTestCase):
 
     def test_tags_created_automatically_for_user(self):
         ''' Assert that a UserTag is created for a user when they hit an endpoint after a Tag has been created. '''
-        tag1 = models.Tag(name='tag1')
-        tag2 = models.Tag(name='tag2')
+        tag1 = Tag(name='tag1')
+        tag2 = Tag(name='tag2')
         tag1.save()
         tag2.save()
-        self.assertEquals(models.UserTag.objects.count(), 0)
+        self.assertEquals(UserTag.objects.count(), 0)
 
         self._login()
         self._assert_no_questions()
 
         # Assert that QuestionTags were created for this user
-        user_tags = models.UserTag.objects.all()
+        user_tags = UserTag.objects.all()
         self.assertEquals(len(user_tags), 2)
         tag_ids = {user_tag.tag.id for user_tag in user_tags}
         user_ids = {user_tag.user.id for user_tag in user_tags}
@@ -137,19 +140,19 @@ class BrowserTests(LiveServerTestCase):
 
     def test_only_show_questions_with_tag_selected(self):
         ''' Assert that only questions with a given tag are shown '''
-        tag1 = models.Tag(name='tag1')
-        tag2 = models.Tag(name='tag2')
+        tag1 = Tag(name='tag1')
+        tag2 = Tag(name='tag2')
         tag1.save()
         tag2.save()
 
-        question1 = models.Question(question="question1")
-        question2 = models.Question(question="question2")
+        question1 = Question(question="question1")
+        question2 = Question(question="question2")
         question1.save()
         question2.save()
 
-        self.assertEquals(models.Question.objects.all().count(), 2)
-        self.assertEquals(models.QuestionTag.objects.all().count(), 0)
-        self.assertEquals(models.UserTag.objects.all().count(), 0)
+        self.assertEquals(Question.objects.all().count(), 2)
+        self.assertEquals(QuestionTag.objects.all().count(), 0)
+        self.assertEquals(UserTag.objects.all().count(), 0)
 
         self._login()
         # Assert no questions, because user doesn't have any tags selected.
@@ -165,13 +168,13 @@ class BrowserTests(LiveServerTestCase):
     def test_confirm_tags_can_be_selected_unselected(self):
         ''' B: tags enabled/disabled during questions and answers are saved
         and carried over'''
-        tag1 = models.Tag(name='tag1')
-        tag2 = models.Tag(name='tag2')
+        tag1 = Tag(name='tag1')
+        tag2 = Tag(name='tag2')
         tag1.save()
         tag2.save()
 
-        question1 = models.Question(question="question1")
-        question2 = models.Question(question="question2")
+        question1 = Question(question="question1")
+        question2 = Question(question="question2")
         question1.save()
         question2.save()
 
@@ -183,194 +186,223 @@ class BrowserTests(LiveServerTestCase):
 
 class NonBrowserTests(TestCase):
 
+    def test_schedule_save(self):
+        my_datetime = datetime(year=2017, month=07, day=04)
+        question = Question.objects.create()
+        schedule1 = Schedule.objects.create(question=question)
+        schedule2 = Schedule.objects.create(date_show_next=my_datetime, question=question)
+
+        now = datetime.now(tz=pytz.utc)
+        self.assertTrue((now - timedelta(seconds=5)) < schedule1.date_show_next < now)
+        self.assertEquals(schedule2.date_show_next, my_datetime)
+
     def test_get_next_question(self):
-        ''' Assert that views.next_question() works correctly. '''
-        user1 = User(email="user1@bednark.com")
-        user2 = User(email="user2@bednark.com")
-        user1.save()
-        user2.save()
+        # expected number of queries
+        NUM_QUERIES_SCHEDULED_BEFORE_NOW = 3  # scheduled question is due to be shown before now
+        NUM_QUERIES_UNSCHEDULED_QUESTION = 4  # there are no scheduled questions, and an uncheduled question is returned
+        NUM_QUERIES_SCHEDULED_AFTER_NOW = 5   # no scheduled questions before now, no unscheduled questions, and a scheduled question after now is shown
+        NUM_QUERIES_NO_QUESTIONS = 5  # number of queries expected when no questions are found
 
-        tag1 = models.Tag(name='tag1')
-        tag2 = models.Tag(name='tag2')
-        tag1.save()
-        tag2.save()
+        # test _get_next_question()
+        user1 = User.objects.create(email="user1@bednark.com")
+        user2 = User.objects.create(email="user2@bednark.com")
 
-        question1 = models.Question(question="question1")
-        question2 = models.Question(question="question2")
-        question1.save()
-        question2.save()
+        tag1 = Tag.objects.create(name='tag1')
+        tag2 = Tag.objects.create(name='tag2')
 
-        # Asserts: 2 questions
-        #          0 QuestionTag's
-        #          0 UserTag's
-        self.assertEquals(models.Question.objects.all().count(), 2)
-        self.assertEquals(models.QuestionTag.objects.all().count(), 0)
-        self.assertEquals(models.UserTag.objects.all().count(), 0)
+        question1 = Question.objects.create(question="question1")
+        question2 = Question.objects.create(question="question2")
 
+        # Test: no question when no UserTags
         # Given:
-        #   a) user1 with 0 tags
+        #   a) user1 with 0 UserTags
         #   b) 0 questions with any tags
         #   c) 2 questions with 0 tags
         #   d) tag1 and tag2 each have 0 questions
-        # Assert: user does not get a question
-        with self.assertNumQueries(2):
+        # Assert: user does not get a question, because they have no UserTags
+        self.assertTrue(UserTag.objects.filter(user=user1).count() == 0)
+        self.assertTrue(Question.objects.all().count() == 2)
+        self.assertTrue(QuestionTag.objects.all().count() == 0)
+        self.assertTrue(Schedule.objects.all().count() == 0)
+        self.assertTrue(Tag.objects.all().count() == 2)
+        self.assertTrue(UserTag.objects.all().count() == 0)
+        with self.assertNumQueries(NUM_QUERIES_NO_QUESTIONS):
             next_question = _get_next_question(user=user1)
-            self.assertIsNone(next_question.question)
+            self.assertTrue(next_question.question is None)
 
+        # Test: no question when UserTag but no questions with that tag
         # Given:
         #   a) user1 with 1 UserTag
         #   b) 0 questions with that UserTag
-        # Assert: iuser1 does not get a question
-        user1_tag1 = models.UserTag(user=user1, tag=tag1, enabled=True)
-        user1_tag1.save()
-        self.assertEquals(
-            models.UserTag.objects.filter(user=user1).count(), 1
-        )
-        self.assertEquals(models.QuestionTag.objects.filter(tag=tag1).count(), 0)
+        # Assert: user1 does not get a question, because there are no questions with that UserTag
+        user1_tag1 = UserTag.objects.create(user=user1, tag=tag1, enabled=True)
+        self.assertTrue(user1_tag1.tag.questions.count() == 0)
+        self.assertTrue(
+            UserTag.objects.filter(user=user1).count() == 1)
+        self.assertTrue(QuestionTag.objects.filter(tag=tag1).count() == 0)
 
         for _ in range(5):
-            with self.assertNumQueries(2):
+            with self.assertNumQueries(NUM_QUERIES_NO_QUESTIONS):
                 next_question = _get_next_question(user=user1)
-                self.assertIsNone(next_question.question)
+                self.assertTrue(next_question.question is None)
 
+        # Bucket 2: question with no schedules
+        # Test: No questions with schedules, so returned oldest question.datetime_added
         # Given:
         #    a) user1 with tag user1_tag1
-        #    b) question1 with tag1
+        #    b) question1 and question2 have tag1
         #    c) user has 0 schedules
-        # Assert: user1 gets no question because it was not added before question2
-        question1_tag1 = models.QuestionTag(
+        #    d) question1.datetime_added < question2.datetime_added
+        # Assert: user1 gets question1 because it was added before question2
+        question1_tag1 = QuestionTag.objects.create(
             question=question1, tag=tag1, enabled=True
         )
-        question1_tag1.save()
-        self.assertEquals(
-            question1.datetime_added < question2.datetime_added, True
-        )
-        self.assertEquals(models.Question.objects.all().count(), 2)
-        self.assertEquals(models.UserTag.objects.filter(user=user1).count(), 1)
-        self.assertEquals(models.QuestionTag.objects.all().count(), 1)
-        self.assertEquals(
-            models.QuestionTag.objects.filter(tag=tag1, enabled=True).count(), 1
-        )
-        self.assertEquals(models.Schedule.objects.filter(user=user1).count(), 0)
-
-        for n in range(4):
-            with self.assertNumQueries(2):
-                next_question = _get_next_question(user=user1)
-                self.assertIsNone(next_question.question)
-
-
-        # Given:
-        #    a) user1 with tag user1_tag1
-        #    b) question1 with tag1
-        #    c) tag1.enabled == False
-        #    d) user has 0 schedules
-        # Assert: no question is returned
-        question1_tag1.enabled = False
-        question1_tag1.save()
-        self.assertEquals(
-            models.QuestionTag.objects.filter(tag=tag1, enabled=True).count(), 0
-        )
-        self.assertEquals(
-            models.QuestionTag.objects.filter(tag=tag1, enabled=False).count(), 1
-        )
-        for _ in range(4):
-            with self.assertNumQueries(2):
-                next_question = _get_next_question(user=user1)
-
-                self.assertIsNone(next_question.question)
-
-        # Given:
-        #       a) question1 and question2 both have tag1
-        #       b) question1 has 1 schedule and question2 has 0 schedules
-        # Assert: question1 is returned because it has a schedule
-        question1_tag1.enabled = True
-        question1_tag1.save()
-        question2_tag1 = models.QuestionTag(
+        question2_tag1 = QuestionTag.objects.create(
             question=question2, tag=tag1, enabled=True
         )
+        self.assertTrue(question1.datetime_added < question2.datetime_added)
+        self.assertTrue(Question.objects.all().count() == 2)
+        self.assertTrue(UserTag.objects.filter(user=user1).count() == 1)
+        self.assertTrue(QuestionTag.objects.all().count() == 2)
+        self.assertTrue(
+            QuestionTag.objects.filter(tag=tag1, enabled=True).count() == 2
+        )
+        self.assertTrue(Schedule.objects.filter(user=user1).count() == 0)
+
+        for n in range(4):
+            with self.assertNumQueries(NUM_QUERIES_UNSCHEDULED_QUESTION):
+                next_question = _get_next_question(user=user1)
+                self.assertTrue(next_question.question == question1)
+
+        # Test: No question returned when tag.enabled == False
+        # Given:
+        #    a) user1 with tag user1_tag1
+        #    b) question1 and question2 with tag1
+        #    c) tag1.enabled == False
+        #    d) user has 0 schedules
+        # Assert: no question is returned because tag1.enabled == False
+        question1_tag1.enabled = False
+        question2_tag1.enabled = False
+        question1_tag1.save()
         question2_tag1.save()
-        q1_sched1 = models.Schedule(
+        self.assertEquals(
+            QuestionTag.objects.filter(tag=tag1, enabled=True).count(), 0
+        )
+        self.assertEquals(
+            QuestionTag.objects.filter(tag=tag1, enabled=False).count(), 2
+        )
+        for _ in range(4):
+            with self.assertNumQueries(NUM_QUERIES_NO_QUESTIONS):
+                next_question = _get_next_question(user=user1)
+                self.assertTrue(next_question.question is None)
+
+        # Bucket 2: question with no schedules
+        # Test: question with no schedules returned (when another question with schedule.date_show_next > now)
+        # Given:
+        #       a) question1 and question2 both have tag1
+        #       b) question1 has 1 schedule with date_show_now > now
+        #       c) question2 has 0 schedules
+        # Assert: question2 is returned because question1 is not ready to be shown yet,
+        #         and question2 has no schedules
+        question1_tag1.enabled = True
+        question1_tag1.save()
+        question2_tag1.enabled = True
+        question2_tag1.save()
+        q1_sched1 = Schedule.objects.create(
             user=user1,
             question=question1,
             interval_num=1,
-            interval_unit='weeks'
-        )
-        q1_sched1.save()
-        self.assertEquals(
-            models.QuestionTag.objects.filter(tag=tag1, enabled=True).count(), 2
-        )
-        self.assertEquals(models.Schedule.objects.all().count(), 1)
-        self.assertEquals(
-            models.Question.objects.get(id=question1.id).schedule_set.count(), 1
-        )
+            interval_unit='weeks')
+        self.assertTrue(q1_sched1.date_show_next > datetime.now(tz=pytz.utc))
+        self.assertTrue(QuestionTag.objects.filter(tag=tag1, enabled=True).count() == 2)
+        self.assertTrue(Schedule.objects.all().count() == 1)
+        self.assertTrue(Schedule.objects.filter(question=question1).count() == 1)
+        self.assertTrue(Schedule.objects.filter(question=question2).count() == 0)
+        self.assertTrue(Question.objects.get(id=question1.id).schedule_set.count() == 1)
         for _ in range(5):
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(NUM_QUERIES_UNSCHEDULED_QUESTION):
                 next_question = _get_next_question(user=user1)
+                self.assertTrue(next_question.question == question2)
 
-                self.assertEquals(next_question.question, question1)
-
-        # Add a schedule to question2 with a later scheduled date, and assert that question1 is returned
+        # Bucket 1: question.schedule.date_show_next < now
+        # Given 2 questions with date_show_next < now, show the question with the latest date_show_next
         # Given:
         #       a) question1 and question2 both have tag1
         #       b) question1 has 2 schedules, question2 has 1 schedule
-        #       b) question2's newest schedule is earlier than question1's schedule
-        # Assert: question2 is returned because it has an earlier schedule
-        q2_sched1 = models.Schedule(
+        #       c) question1's newest schedule (q1_sched2) has date_show_next > question2's schedule.date_show_next
+        #       d) question1's newest schedule (q1_sched2) has date_show_next < now
+        #       e) question1's oldest schedule (q1_sched1) has date_show_next < now
+        #       f) question2's schedule (q2_sched1) has date_show_next < now
+        #       g) question1's newest schedule (q1_sched2).date_show_next > q2_sched1.date_show_next
+        # Assert: question1 is returned because it has a later schedule.date_show_next
+        q2_sched1 = Schedule.objects.create(
             user=user1,
             question=question2,
             interval_num=1,
-            interval_unit='months'
-        )
-        q1_sched2 = models.Schedule(
+            interval_unit='months',
+            date_show_next=datetime.now(tz=pytz.utc) - timedelta(days=2))
+        q1_sched2 = Schedule.objects.create(
             user=user1,
             question=question1,
             interval_num=1,
-            interval_unit='days'
-        )
-        q1_sched2.save()
+            interval_unit='days',
+            date_show_next=datetime.now(tz=pytz.utc) - timedelta(days=1))
+        q1_sched1.date_show_next = datetime.now(tz=pytz.utc) - timedelta(days=1)
+        q1_sched1.save()
         q2_sched1.save()
-        self.assertEquals(
-            q2_sched1.date_show_next > q1_sched2.date_show_next, True
-        )
-        self.assertEquals(models.Schedule.objects.all().count(), 3)
+        self.assertTrue(q1_sched2.datetime_added > q1_sched1.datetime_added)
+        self.assertTrue(q1_sched2.date_show_next > q2_sched1.date_show_next)
+        self.assertTrue(q1_sched1.date_show_next < datetime.now(tz=pytz.utc))
+        self.assertTrue(q1_sched2.date_show_next < datetime.now(tz=pytz.utc))
+        self.assertTrue(q2_sched1.date_show_next < datetime.now(tz=pytz.utc))
+        self.assertTrue(Schedule.objects.all().count() == 3)
         for _ in range(5):
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(NUM_QUERIES_SCHEDULED_BEFORE_NOW):
                 next_question = _get_next_question(user=user1)
+                self.assertEquals(next_question.question, question1)
 
-                self.assertEquals(next_question.question, question2)
-
-        # Add a 2nd schedule to question2 earlier than question1's schedule,
+        # Bucket 3: question.schedule_date_show_next > now
+        # Add a 2nd schedule to question2 such that:
+        #    now < question2's schedule.date_show_next < question1's schedule.date_show_next
         # and assert that question2 is now returned
         # Given:
-        # a) question1 and question2 both have tag1
-        # b) question1 and question2 each have 2 schedules
-        # c) question2's newest schedule is earlier than question1's
-        #    newest schedule
-        # Assert that question2 is returned because it's schedule is earlier
-        q2_sched2 = models.Schedule(
+        #   a) question1 and question2 both have tag1
+        #   b) question1 and question2 each have 2 schedules
+        #   c) q2's newest schedule is q2_sched2, q1's newest is q1_sched2
+        #   d) q2_sched2.date_show_next > now < q1_sched2.date_show_next
+        # Assert that question2 is returned because it's schedule was added later.
+        q2_sched2 = Schedule.objects.create(
             user=user1,
             question=question2,
             interval_num=5,
-            interval_unit='minutes'
+            interval_unit='minutes',
+            date_show_next=datetime.now(tz=pytz.utc) + timedelta(minutes=1)
         )
-        q2_sched2.save()
-        self.assertEquals(
-            q2_sched2.date_show_next < q1_sched1.date_show_next, True
-        )
+        q1_sched2.date_show_next = datetime.now(tz=pytz.utc) + timedelta(minutes=2)
+        q1_sched2.save()
+        self.assertTrue(q2_sched2.date_show_next > datetime.now(tz=pytz.utc))
+        self.assertTrue(q1_sched2.date_show_next > datetime.now(tz=pytz.utc))
+        self.assertTrue(q2_sched2.date_show_next < q1_sched2.date_show_next)
+        self.assertTrue(q2_sched2.datetime_added > q2_sched1.datetime_added)
+        self.assertTrue(q1_sched2.datetime_added > q1_sched1.datetime_added)
+        question1.refresh_from_db()
+        question2.refresh_from_db()
+        self.assertTrue(question1.schedule_set.count() == 2)
+        self.assertTrue(question1.schedule_set.count() == 2)
         for _ in range(5):
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(NUM_QUERIES_SCHEDULED_AFTER_NOW):
+                if True:
+                    # trigger the debugger
+                    pytz.show = False
                 next_question = _get_next_question(user=user1)
-
                 self.assertEquals(next_question.question, question2)
 
         # Add a new question with a different tag, and assert that it
         # doesn't affect the question returned
-        question3 = models.Question(question="question3")
-        question3.save()
+        Question.objects.create(question="question3")
         for _ in range(5):
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(NUM_QUERIES_SCHEDULED_AFTER_NOW):
                 next_question = _get_next_question(user=user1)
-
                 self.assertEquals(next_question.question, question2)
 
 
@@ -436,12 +468,12 @@ class ViewAnswerTests(TestCase):
         self.user.save()
 
         # Create 1 answer, 1 question, and 1 attempt
-        self.answer = models.Answer.objects.create(answer='fakefoo')
-        self.question = models.Question.objects.create(
+        self.answer = Answer.objects.create(answer='fakefoo')
+        self.question = Question.objects.create(
             question='fakebar',
             answer=self.answer
         )
-        self.attempt = models.Attempt.objects.create(
+        self.attempt = Attempt.objects.create(
             attempt='fakebaz',
             question=self.question
         )
@@ -461,8 +493,8 @@ class ViewAnswerTests(TestCase):
 
     def test_viewanswer_post(self):
         # Create a tag and link the tag to self.user via UserTag
-        tag = models.Tag.objects.create(name='faketag')
-        user_tag = models.UserTag.objects.create(user=self.user, tag=tag)
+        tag = Tag.objects.create(name='faketag')
+        user_tag = UserTag.objects.create(user=self.user, tag=tag)
         self.modelformset_usertag_dict['form-0-id'] = user_tag.id
         # Log in
         logged_in = self.client.login(
@@ -472,7 +504,7 @@ class ViewAnswerTests(TestCase):
 
         # Make sure there's no preexisting schedule
         self.assertFalse(
-            models.Schedule.objects.filter(question=self.question).exists()
+            Schedule.objects.filter(question=self.question).exists()
         )
 
         # POST to the answer page
@@ -492,7 +524,7 @@ class ViewAnswerTests(TestCase):
         self.assertTrue(logged_in)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
-            models.Schedule.objects.filter(
+            Schedule.objects.filter(
                 question=self.question
             ).count(),
             1


### PR DESCRIPTION
o change get_next_question to a new algorithm:
    if there are questions scheduled before now:
       return the question with the newest schedule.datetime_added
    elif there are unscheduled questions:
       return the unscheduled question with the oldest question.datetime_added
    elif there are questions scheduled after now:
        return the question with the oldest schedule.date_show_next
    else:
        return nothing
o improve query performance by using subqueries
o put displayed question tag names in alphabetical order
o don't update Schedule.date_show_next when modifying a schedule (e.g., in
  the Django admin)

All automated tests pass.