### PR TITLE
Merge: 2024-10-20--admin-order-tags-by-name => master

### DIFF
--- a/questions/admin.py
+++ b/questions/admin.py
@@ -17,7 +17,7 @@ class TagQuestionRelationshipInline(admin.TabularInline):
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         # Only show tags owned by the user
         if db_field.name == "tag":
-            kwargs["queryset"] = Tag.objects.filter(user=request.user)
+            kwargs["queryset"] = Tag.objects.filter(user=request.user).order_by('name')
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
@@ -172,7 +172,7 @@ class QuestionAdmin(admin.ModelAdmin):
     def tags_display(self, obj):
         # Use for list_display to show the names of all the tags (a many-to-many field)
         return ", ".join([
-            tag.name for tag in obj.tag_set.all()
+            tag.name for tag in obj.tag_set.all().order_by('name')
         ])
     tags_display.short_description = "Tags"
 

--- a/questions/get_tag_hierarchy.py
+++ b/questions/get_tag_hierarchy.py
@@ -78,6 +78,7 @@ def get_tag_hierarchy(user):
             raise ValueError(f'type_=[{type_}] but must be either "ancestors" or "descendants"')
 
     tags = Tag.objects.filter(user=user)
+    tags = tags.prefetch_related('parents', 'children')
     hierarchy = {}
 
     for type_ in ['ancestors', 'descendants']:

--- a/questions/models.py
+++ b/questions/models.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from six import python_2_unicode_compatible
 
 from dateutil.relativedelta import relativedelta
 
@@ -29,7 +28,6 @@ class CreatedBy(models.Model):
     class Meta:
         abstract = True
 
-@python_2_unicode_compatible
 class Question(CreatedBy):
     question = models.TextField()
     answer = models.ForeignKey('Answer', on_delete=models.SET_NULL, null=True, blank=True)
@@ -44,7 +42,6 @@ class Question(CreatedBy):
         return '<Question id=[%s] question=[%s] datetime_added=[%s]>' % (self.id, self.question, self.datetime_added)
 
 
-@python_2_unicode_compatible
 class Answer(CreatedBy):
     answer = models.TextField()
     # question_set
@@ -61,7 +58,6 @@ class Attempt(CreatedBy):
     # user
     # user_set
 
-@python_2_unicode_compatible
 class Tag(CreatedBy):
     '''
         Each tag can be applied to each question for a given user.
@@ -83,7 +79,6 @@ class Tag(CreatedBy):
         return self.name
 
 
-@python_2_unicode_compatible
 class TagLineage(CreatedBy):
     # A tag can have 0..n tags as children
     # related_name is the name for the reverse relationship.  
@@ -101,7 +96,6 @@ class TagLineage(CreatedBy):
         return f'TagLineage: parent_tag=[{self.parent_tag.name}] child_tag=[{self.child_tag.name}]'
 
 
-@python_2_unicode_compatible
 class QuestionTag(CreatedBy):
     # This is a tag applied to a question.
     # e.g., question = Question(text="1 + 1 = ??")

--- a/questions/tests/test_get_tag_hierarchy.py
+++ b/questions/tests/test_get_tag_hierarchy.py
@@ -121,12 +121,7 @@ class TestGetTagHierarchy:
         assert len(user1_hierarchy) == 1
         assert len(user2_hierarchy) == 1
         assert list(user1_hierarchy.values())[0]['tag_name'] == "user1_tag"
-<<<<<<< HEAD
         assert list(user2_hierarchy.values())[0]['tag_name'] == "user2_tag"
-=======
-
-        assert list(user2_hierarchy.values())[0]['tag_name'] == "user2_tag"
-
 
 class TestExpandAllTagIds:
 
@@ -167,4 +162,3 @@ class TestExpandAllTagIds:
     def test_expand_nonexistent_tag(self, sample_hierarchy):
         with pytest.raises(KeyError):
             expand_all_tag_ids(sample_hierarchy, [6])
->>>>>>> a8e56b2 (Use tag descendants in NextQuestion (see below))

--- a/questions/tests/test_get_tag_hierarchy.py
+++ b/questions/tests/test_get_tag_hierarchy.py
@@ -1,5 +1,9 @@
 import pytest
+
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
 from questions.models import Question, Tag, TagLineage
 from questions.get_tag_hierarchy import expand_all_tag_ids, get_tag_hierarchy
 
@@ -39,7 +43,10 @@ class TestGetTagHierarchy:
 
     def test_tag_hierarchy_structure(self, user, setup_tags):
         parent, child1, child2, grandchild = setup_tags
-        hierarchy = get_tag_hierarchy(user)
+        with CaptureQueriesContext(connection) as context:
+            assert len(context) == 0, "Should be 0 queries before the call to get_tag_hierarchy()"
+            hierarchy = get_tag_hierarchy(user)
+            assert len(context) == 27
 
         assert len(hierarchy) == 4
         assert all(tag_id in hierarchy for tag_id in [parent.id, child1.id, child2.id, grandchild.id])


### PR DESCRIPTION
o admin.py: order tags by name in dropdowns for Question, Tag, TagLineage
o PERFORMANCE: get_tag_hierarchy: add prefetch_related('parents','children') to reduce queries
   This reduced the number of queries from 33 to 27 for one of the tests.
   Added asserting number of queries to one test
o TEST FIX: fix conflict that I missed from earlier rebase
o Remove unneeded @python_2_unicode_compatible decorators
   No longer needed since moving to Python3