### PR TITLE
Optimize query performance for tag hierarchy from O(n) or greater to 3 queries

### DIFF
--- a/questions/get_tag_hierarchy.py
+++ b/questions/get_tag_hierarchy.py
@@ -77,7 +77,6 @@ def get_tag_hierarchy(user):
                 if child_tag.id not in visited:
                     build_hierarchy(hierarchy=hierarchy, tag=child_tag, type_=type_, visited=visited)
                     hierarchy[tag.id]['children'].add(child_tag.id)
-                    # hierarchy[tag.id]['descendants'].add(child_tag.id)
                     hierarchy[tag.id]['descendants'].update(hierarchy[child_tag.id]['descendants_and_self'])
                     hierarchy[tag.id]['descendants_and_self'].update(hierarchy[child_tag.id]['descendants_and_self'])
             hierarchy[tag.id]['descendants_and_self'].add(tag.id)  # add self

--- a/questions/models.py
+++ b/questions/models.py
@@ -23,7 +23,7 @@ CHOICES_UNITS = (
 class CreatedBy(models.Model):
     datetime_added = models.DateTimeField(auto_now_add=True)
     datetime_updated = models.DateTimeField(auto_now=True)
-    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=False)
 
     class Meta:
         abstract = True

--- a/questions/tests/test_get_tag_hierarchy.py
+++ b/questions/tests/test_get_tag_hierarchy.py
@@ -47,7 +47,7 @@ class TestGetTagHierarchy:
         with CaptureQueriesContext(connection) as context:
             assert len(context) == 0, "Should be 0 queries before the call to get_tag_hierarchy()"
             hierarchy = get_tag_hierarchy(user)
-            assert len(context) == 20
+            assert len(context) == 3 # query count
 
         assert len(hierarchy) == 4
         assert all(tag_id in hierarchy for tag_id in [parent.id, child1.id, child2.id, grandchild.id])


### PR DESCRIPTION
Merge: rob-bednark-2024-10-24--optimize-tag-hierarchy-query-performance => master

Optimize query performance for tag hierarchy from O(n) or greater to 3 queries

PERFORMANCE: decrease queries needed for tag hierarchy from, e.g., 20 to 3 (constant)
PERFORMANCE: get_tag_hierarchy: use a single query for all QuestionTag's
FUTURE: implement get_all_questions_for_tag_ids(), which is not yet used.
COMMENT: remove commented-out code
FORMS: require user 
    models.CreatedBy.user: change to blank=False
    This is used when adding models via a form, to ensure .user field is set to something
