### PR TITLE
new "OLDEST DUE OR UNSEEN" query; ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@
 #   PGDATABASE=template1 make loaddb
 
 SHELL := /bin/bash -xv
+
+# The following variables that are not set to anything need to be set when calling make.
+#    e.g., DB_NAME_TO_DUMP='my-db' make dumpdb
 # DB_NAME_TO_DUMP = name of the db to dump
 DB_NAME_TO_DUMP=
 DB_NAME_TO_RESTORE_CUSTOM=restore_quizme_custom
@@ -37,11 +40,13 @@ DB_CONNECTION_STRING:=postgres://${DB_USER}:${DB_PASSWORD}@${DB_SERVER}:${DB_POR
 DIR_DUMPS=db_dumps
 FILE_DUMP_CUSTOM:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.custom.all
 FILE_DUMP_DUMPDATA:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.dumpdata.json
+FILE_DUMP_EXPORT_TAGS:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.export_tags.csv
 FILE_DUMP_PLAIN_ALL:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.plain.all
 FILE_DUMP_PLAIN_DATA:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.plain.data-only
 FILE_DUMP_PLAIN_SCHEMA:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.plain.schema-only
 FILE_DUMP_TEXT:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.txt
 SYMLINK_LATEST_TEXT:=${DIR_DUMPS}/latest.dump.txt
+USER_ID_EXPORT_TAGS=
 
 first_target:
 	echo "This is the default target and it does nothing.  Specify a target."
@@ -70,6 +75,7 @@ dumpdb:
 	gzip ${FILE_DUMP_PLAIN_DATA}
 	time pg_dump --schema-only --format=plain ${DB_CONNECTION_STRING} > ${FILE_DUMP_PLAIN_SCHEMA}
 	DB_QUIZME=${DB_NAME_TO_DUMP} PYTHONIOENCODING=utf-8 poetry run python ./manage.py dump > ${FILE_DUMP_TEXT} 2>&1
+	DB_QUIZME=${DB_NAME_TO_DUMP} poetry run python ./manage.py export_tags --user-id=${USER_ID_EXPORT_TAGS} > ${FILE_DUMP_EXPORT_TAGS} 2>&1
 	DB_QUIZME=${DB_NAME_TO_DUMP} poetry run python ./manage.py dumpdata --all --indent=2 > ${FILE_DUMP_DUMPDATA} 2>&1
 	gzip ${FILE_DUMP_DUMPDATA}
 	rm -f ${SYMLINK_LATEST_TEXT}

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ FILE_DUMP_PLAIN_ALL:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.plain.all
 FILE_DUMP_PLAIN_DATA:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.plain.data-only
 FILE_DUMP_PLAIN_SCHEMA:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.plain.schema-only
 FILE_DUMP_TEXT:=${DIR_DUMPS}/dump.${DB_NAME_TO_DUMP}.txt
-SYMLINK_LATEST_TEXT:=${DIR_DUMPS}/latest.dump.txt
 USER_ID_EXPORT_TAGS=
 
 first_target:
@@ -78,8 +77,6 @@ dumpdb:
 	DB_QUIZME=${DB_NAME_TO_DUMP} poetry run python ./manage.py export_tags --user-id=${USER_ID_EXPORT_TAGS} > ${FILE_DUMP_EXPORT_TAGS} 2>&1
 	DB_QUIZME=${DB_NAME_TO_DUMP} poetry run python ./manage.py dumpdata --all --indent=2 > ${FILE_DUMP_DUMPDATA} 2>&1
 	gzip ${FILE_DUMP_DUMPDATA}
-	rm -f ${SYMLINK_LATEST_TEXT}
-	ln -s `basename ${FILE_DUMP_TEXT}` ${SYMLINK_LATEST_TEXT}
 	ls -hltr db_dumps/. |tail -8
 
 flake8:

--- a/questions/forms.py
+++ b/questions/forms.py
@@ -9,6 +9,8 @@ QUERY_OLDEST_DUE = 'OLDEST DUE'
 QUERY_FUTURE = 'FUTURE'
 QUERY_ANSWERED_COUNT = 'ANSWERED COUNT'
 QUERY_LAST_SEEN_BY_TAG = 'LAST-SEEN BY TAG'
+QUERY_OLDEST_VIEWED= 'OLDEST VIEWED'
+QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG = 'OLDEST VIEWED BY OLDEST-VIEWED TAG'
 QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG = 'UNSEEN BY OLDEST-VIEWED TAG'
 QUERY_REINFORCE_THEN_UNSEEN = 'REINFORCE, UNSEEN'
 QUERY_REINFORCE_THEN_UNSEEN_THEN_FUTURE = 'REINFORCE, UNSEEN, FUTURE'
@@ -22,6 +24,8 @@ QUERY_CHOICES = (
     (QUERY_FUTURE, f'{QUERY_FUTURE}: notes due after now, ordered by due date ascending'),
     # (QUERY_ANSWERED_COUNT, f'{QUERY_ANSWERED_COUNT}: ordered by # times seen, ascending (NOTE: this will see all notes)'),
     # (QUERY_LAST_SEEN_BY_TAG, f'{QUERY_LAST_SEEN_BY_TAG}: find the oldest last_seen date for each tag; show note from the oldest tag (tags with notes but no schedules should be shown first)'),
+    (QUERY_OLDEST_VIEWED, f'{QUERY_OLDEST_VIEWED}: "oldest-viewed" is the older of the oldest Schedule.datetime_added, or if no Schedules, then the oldest Question.datetime_added.'),
+    (QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG, f'{QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG}: "oldest-viewed" is the older of the oldest Schedule.datetime_added, or if no Schedules, then the oldest Question.datetime_added.'),
     (QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG, f'{QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG}: "oldest-viewed tag" is the tag with the oldest Schedule.datetime_added.  Or, if no Schedules, then the oldest Question.datetime_added.'),
     # (QUERY_REINFORCE_THEN_UNSEEN, f'{QUERY_REINFORCE_THEN_UNSEEN}: REINFORCE, then UNSEEN'),
     # (QUERY_REINFORCE_THEN_UNSEEN_THEN_FUTURE, f'{QUERY_REINFORCE_THEN_UNSEEN_THEN_FUTURE}: REINFORCE, then UNSEEN, then FUTURE'),
@@ -36,6 +40,8 @@ ALL_QUERY_NAMES = (
     QUERY_FUTURE,
     QUERY_ANSWERED_COUNT,
     QUERY_LAST_SEEN_BY_TAG,
+    QUERY_OLDEST_VIEWED,
+    QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG,
     QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG,
     QUERY_REINFORCE_THEN_UNSEEN,
     QUERY_REINFORCE_THEN_UNSEEN_THEN_FUTURE,

--- a/questions/forms.py
+++ b/questions/forms.py
@@ -9,7 +9,7 @@ QUERY_OLDEST_DUE = 'OLDEST DUE'
 QUERY_FUTURE = 'FUTURE'
 QUERY_ANSWERED_COUNT = 'ANSWERED COUNT'
 QUERY_LAST_SEEN_BY_TAG = 'LAST-SEEN BY TAG'
-QUERY_OLDEST_VIEWED= 'OLDEST VIEWED'
+QUERY_OLDEST_VIEWED= 'OLDEST DUE OR UNSEEN'
 QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG = 'OLDEST VIEWED BY OLDEST-VIEWED TAG'
 QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG = 'UNSEEN BY OLDEST-VIEWED TAG'
 QUERY_REINFORCE_THEN_UNSEEN = 'REINFORCE, UNSEEN'
@@ -24,8 +24,8 @@ QUERY_CHOICES = (
     (QUERY_FUTURE, f'{QUERY_FUTURE}: notes due after now, ordered by due date ascending'),
     # (QUERY_ANSWERED_COUNT, f'{QUERY_ANSWERED_COUNT}: ordered by # times seen, ascending (NOTE: this will see all notes)'),
     # (QUERY_LAST_SEEN_BY_TAG, f'{QUERY_LAST_SEEN_BY_TAG}: find the oldest last_seen date for each tag; show note from the oldest tag (tags with notes but no schedules should be shown first)'),
-    (QUERY_OLDEST_VIEWED, f'{QUERY_OLDEST_VIEWED}: "oldest-viewed" is the older of the oldest Schedule.datetime_added, or if no Schedules, then the oldest Question.datetime_added.'),
-    (QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG, f'{QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG}: "oldest-viewed" is the older of the oldest Schedule.datetime_added, or if no Schedules, then the oldest Question.datetime_added.'),
+    (QUERY_OLDEST_VIEWED, f'{QUERY_OLDEST_VIEWED}: for each question, Schedule.date_show_next, or if no Schedules, then Question.datetime_added'),
+    # (QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG, f'{QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG}: "oldest-viewed" is the older of the oldest Schedule.datetime_added, or if no Schedules, then the oldest Question.datetime_added.'),
     (QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG, f'{QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG}: "oldest-viewed tag" is the tag with the oldest Schedule.datetime_added.  Or, if no Schedules, then the oldest Question.datetime_added.'),
     # (QUERY_REINFORCE_THEN_UNSEEN, f'{QUERY_REINFORCE_THEN_UNSEEN}: REINFORCE, then UNSEEN'),
     # (QUERY_REINFORCE_THEN_UNSEEN_THEN_FUTURE, f'{QUERY_REINFORCE_THEN_UNSEEN_THEN_FUTURE}: REINFORCE, then UNSEEN, then FUTURE'),

--- a/questions/get_next_question.py
+++ b/questions/get_next_question.py
@@ -4,7 +4,7 @@ from django.db.models import F, Max, Min, OuterRef, Q, Subquery
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
-from questions.forms import QUERY_OLDEST_DUE, QUERY_FUTURE, QUERY_REINFORCE, QUERY_UNSEEN, QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG, QUERY_UNSEEN_THEN_OLDEST_DUE
+from questions.forms import QUERY_OLDEST_DUE, QUERY_FUTURE, QUERY_REINFORCE, QUERY_UNSEEN, QUERY_OLDEST_VIEWED, QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG, QUERY_UNSEEN_BY_OLDEST_VIEWED_TAG, QUERY_UNSEEN_THEN_OLDEST_DUE
 from questions.get_tag_hierarchy import expand_all_tag_ids, get_tag_hierarchy
 from questions.models import Question, Schedule, Tag
 from questions.VerifyTagIds import VerifyTagIds
@@ -96,6 +96,10 @@ class NextQuestion:
             pass
         elif self._query_name == QUERY_UNSEEN_THEN_OLDEST_DUE:
             self._get_count_questions_matched_criteria_unseen_then_oldest_due()
+        elif self._query_name == QUERY_OLDEST_VIEWED:
+            pass
+        elif self._query_name == QUERY_OLDEST_VIEWED_DUE_BY_OLDEST_VIEWED_TAG:
+            pass
         else:
             raise ValueError(f'Invalid query name in _get_count_questions_matched_criteria: [{self._query_name}]')
 
@@ -202,6 +206,13 @@ class NextQuestion:
         if self._query_name != QUERY_FUTURE:
             self.count_questions_due = self.count_questions_matched_criteria
             
+
+    def _get_next_question_oldest_viewed(self):
+        pass
+
+    def _get_next_question_oldest_viewed_due_by_oldest_viewed_tag(self):
+        pass
+
     def _get_next_question_unseen(self):
         # Find all questions created by user which have one or more of tag_ids_selected.  Of those questions, find the ones that are unseen, i.e., have no schedules.  Of those, return the one with the oldest datetime_added.
         # Side effects: set the following attributes:
@@ -228,12 +239,12 @@ class NextQuestion:
         self.count_questions_unseen = self.count_questions_matched_criteria
         
     def _get_next_question_unseen_by_oldest_viewed_tag(self):
-        # "oldest-viewed tag" means the tag with the oldest Schedule.datetime_viewed.  Or, if no Schedules, then the oldest Question.datetime_added.
+        # "oldest-viewed tag" means the tag with the older of the oldest Schedule.datetime_viewed,  or if no Schedules, then the oldest Question.datetime_added.
         # Find all tags that have at least one unseen question.
         # For those tags, get the newest Schedule.datetime_added.  
         # If there are no schedules for a tag, then get the oldest Question.datetime_added.
         # Choose the tag with the oldest of those dates, and use the oldest unseen Question.datetime_added for that tag.
-        # Note: do not want to got by unseen_question.datetime_added, because I don't want to see multiple questions from the same tag in a row.  That would be the same as QUERY_UNSEEN.
+        # Note: do not want to go by unseen_question.datetime_added, because I don't want to see multiple questions from the same tag in a row.  That would be the same as QUERY_UNSEEN.
 
         subquery_newest_schedule_dateadded_for_tag = Schedule.objects.filter(
             question__questiontag__tag=OuterRef('pk'),
@@ -246,9 +257,11 @@ class NextQuestion:
             schedule__isnull=True
         ).order_by('datetime_added').values('datetime_added')[:1]
 
+        # oldest_tags may result in multiple matches per tag (multiple unseen questions), with each one of those for the same tag having the same relevant_date.
+        # That won't matter, since we're ordering my relevant_date, selecting only the first (oldest) one.
         oldest_tags = Tag.objects.filter(
             questiontag__question__user=self._user,
-            questiontag__question__schedule__isnull=True,
+            questiontag__question__schedule__isnull=True,  # only select tags with unseen questions
             id__in=self._tag_ids_selected_expanded
         ).annotate(
             newest_schedule_dateadded_for_tag=Subquery(subquery_newest_schedule_dateadded_for_tag),
@@ -292,6 +305,10 @@ class NextQuestion:
             self._get_next_question_unseen_by_oldest_viewed_tag()
         elif self._query_name == QUERY_UNSEEN_THEN_OLDEST_DUE:
             self._get_next_question_unseen_then_oldest_due()
+        elif self._query_name == QUERY_OLDEST_VIEWED:
+            self._get_next_question_oldest_viewed()
+        elif self._query_name == QUERY_OLDEST_VIEWED_BY_OLDEST_VIEWED_TAG:
+            self._get_next_question_oldest_viewed_by_oldest_viewed_tag()
         else:
             raise ValueError(f'Invalid query_name: [{self._query_name}]')
         self._get_tag_names()

--- a/questions/management/commands/export_tags.py
+++ b/questions/management/commands/export_tags.py
@@ -13,11 +13,15 @@ COLUMN_NAME_CHILD_TAG_IDS_TO_ADD = "ACTION: Child Tag IDs to Add"
 COLUMN_NAME_CHILD_TAG_IDS_TO_REMOVE = "ACTION: Child Tag IDs to Remove"
 COLUMN_NAME_PARENT_TAG_IDS_TO_ADD = "ACTION: Parent Tag IDs to Add"
 COLUMN_NAME_PARENT_TAG_IDS_TO_REMOVE = "ACTION: Parent Tag IDs to Remove"
-fieldnames = [
+COLUMN_NAME_COUNT_QUESTIONS_ALL = "Count of Questions for Tag and Descendants"
+COLUMN_NAME_COUNT_QUESTIONS_TAG = "Count of Questions for Tag Only"
+FIELDNAMES = [
     COLUMN_NAME_TAG_ID,
     COLUMN_NAME_TAG_NAME,
     COLUMN_NAME_CHILD_TAG_NAMES,
     COLUMN_NAME_PARENT_TAG_NAMES,
+    COLUMN_NAME_COUNT_QUESTIONS_TAG,
+    COLUMN_NAME_COUNT_QUESTIONS_ALL,
     COLUMN_NAME_TAG_RENAME,
     COLUMN_NAME_CHILD_TAG_IDS_TO_ADD,
     COLUMN_NAME_CHILD_TAG_IDS_TO_REMOVE,
@@ -30,7 +34,7 @@ class Command(BaseCommand):
         parser.add_argument('--user-id', type=int, help='User ID', required=True)
 
     def handle(self, *args, **options):
-        writer = csv.DictWriter(self.stdout, fieldnames=fieldnames)
+        writer = csv.DictWriter(self.stdout, fieldnames=FIELDNAMES)
         writer.writeheader()
         self.tag_hierarchy = get_tag_hierarchy(user=User.objects.get(id=options['user_id']))
         
@@ -44,6 +48,8 @@ class Command(BaseCommand):
                 COLUMN_NAME_TAG_NAME: tag.name,
                 COLUMN_NAME_PARENT_TAG_NAMES: self._get_names_and_ids(tag_id=tag.id, type_='parents'),
                 COLUMN_NAME_CHILD_TAG_NAMES: self._get_names_and_ids(tag_id=tag.id, type_='children'),
+                COLUMN_NAME_COUNT_QUESTIONS_ALL: self.tag_hierarchy[tag.id]['count_questions_all'],
+                COLUMN_NAME_COUNT_QUESTIONS_TAG: self.tag_hierarchy[tag.id]['count_questions_tag'],
             })
 
     def _get_names_and_ids(self, tag_id, type_):

--- a/questions/tests/test_export_tags.py
+++ b/questions/tests/test_export_tags.py
@@ -7,15 +7,12 @@ from django.core.management import call_command
 from questions.management.commands.export_tags import (
     COLUMN_NAME_TAG_ID,
     COLUMN_NAME_TAG_NAME,
-    COLUMN_NAME_TAG_RENAME,
     COLUMN_NAME_CHILD_TAG_NAMES,
-    COLUMN_NAME_CHILD_TAG_IDS_TO_ADD,
-    COLUMN_NAME_CHILD_TAG_IDS_TO_REMOVE,
-    COLUMN_NAME_PARENT_TAG_IDS_TO_ADD,
-    COLUMN_NAME_PARENT_TAG_IDS_TO_REMOVE,
-    COLUMN_NAME_PARENT_TAG_NAMES
+    COLUMN_NAME_PARENT_TAG_NAMES,
+    COLUMN_NAME_COUNT_QUESTIONS_ALL,
+    COLUMN_NAME_COUNT_QUESTIONS_TAG,
 )
-from questions.models import Tag, TagLineage, User
+from questions.models import Question, QuestionTag, Tag, TagLineage, User
 
 # Use the Django database for all the tests
 pytestmark = pytest.mark.django_db
@@ -38,6 +35,15 @@ def setup_tags(user):
 
 def test_export_tags_command(user, setup_tags):
     tag1, tag2, tag3, tag4 = setup_tags
+
+    q1 = Question.objects.create(question="Q1", user=user)
+    q2 = Question.objects.create(question="Q2", user=user)
+    q3 = Question.objects.create(question="Q3", user=user)
+    
+    QuestionTag.objects.create(question=q1, tag=tag1, user=user)
+    QuestionTag.objects.create(question=q2, tag=tag2, user=user)
+    QuestionTag.objects.create(question=q3, tag=tag3, user=user)
+
     file = StringIO()
     call_command('export_tags', f'--user-id={user.id}', stdout=file)
     
@@ -51,32 +57,29 @@ def test_export_tags_command(user, setup_tags):
     assert rows[0][COLUMN_NAME_TAG_NAME] == f'{tag1.name}'
     assert rows[0][COLUMN_NAME_CHILD_TAG_NAMES] == f'{tag2.name} ({tag2.id})'
     assert rows[0][COLUMN_NAME_PARENT_TAG_NAMES] == ''
+    assert rows[0][COLUMN_NAME_COUNT_QUESTIONS_ALL] == '3'
+    assert rows[0][COLUMN_NAME_COUNT_QUESTIONS_TAG] == '1'
 
     assert rows[1][COLUMN_NAME_TAG_ID] == f'{tag2.id}'
     assert rows[1][COLUMN_NAME_TAG_NAME] == f'{tag2.name}'
     assert rows[1][COLUMN_NAME_CHILD_TAG_NAMES] == f'{tag3.name} ({tag3.id})'
     assert rows[1][COLUMN_NAME_PARENT_TAG_NAMES] == f'{tag1.name} ({tag1.id})'
+    assert rows[1][COLUMN_NAME_COUNT_QUESTIONS_ALL] == '2'
+    assert rows[1][COLUMN_NAME_COUNT_QUESTIONS_TAG] == '1'
 
     assert rows[2][COLUMN_NAME_TAG_ID] == f'{tag3.id}'
     assert rows[2][COLUMN_NAME_TAG_NAME] == f'{tag3.name}'
     assert rows[2][COLUMN_NAME_CHILD_TAG_NAMES] == ''
     assert rows[2][COLUMN_NAME_PARENT_TAG_NAMES] == f'{tag2.name} ({tag2.id})'
+    assert rows[2][COLUMN_NAME_COUNT_QUESTIONS_ALL] == '1'
+    assert rows[2][COLUMN_NAME_COUNT_QUESTIONS_TAG] == '1'
 
     assert rows[3][COLUMN_NAME_TAG_ID] == f'{tag4.id}'
     assert rows[3][COLUMN_NAME_TAG_NAME] == f'{tag4.name}'
     assert rows[3][COLUMN_NAME_CHILD_TAG_NAMES] == ''
     assert rows[3][COLUMN_NAME_PARENT_TAG_NAMES] == ''
-
-def test_export_tags_empty(user):
-    out = StringIO()
-    call_command('export_tags', f'--user-id={user.id}', stdout=out)
-    
-    expected_output = (
-        'Tag ID,Tag Name,Child Tag Names,Parent Tag Names,ACTION: Tag Rename,ACTION: Child Tag IDs to Add,'
-        'ACTION: Child Tag IDs to Remove,ACTION: Parent Tag IDs to Add,ACTION: Parent Tag IDs to Remove'
-    )
-    
-    assert out.getvalue().strip() == expected_output.strip()
+    assert rows[3][COLUMN_NAME_COUNT_QUESTIONS_ALL] == '0'
+    assert rows[3][COLUMN_NAME_COUNT_QUESTIONS_TAG] == '0'
 
 def test_export_tags_ordering(user):
     Tag.objects.create(name='zebra', user=user)


### PR DESCRIPTION
o Implemented new "OLDEST DUE OR UNSEEN" query

    Return the question with the oldest due (or, if no Schedules for a question (unseen), Question.datetime_added).
    ("due" is Schedule.date_show_next)

    Note that this is named "OLDEST VIEWED" in most places, but will be changed to "OLDEST DUE OR UNSEEN" in a subsequent commit.

o "manage.py export_tags": add question counts for tag and tag-and-descendants

o Makefile: add "manage.py export_tags" to "dumpdb" target
    e.g.,
        ./manage.py export_tags > dump.quizme.export_tags.csv

o Makefile: remove creation of "latest.dump.txt" symlink in "dumpdb" target
    e.g., no more:
        latest.dump.txt -> dump.quizme.txt

o WIP: started adding "OLDEST VIEWED BY OLDEST-VIEWED TAG" (to be called "OLDEST DUE OR UNSEEN BY TAG")